### PR TITLE
Data Pipeline DynamoDB Export Java Sample

### DIFF
--- a/samples/DynamoDBExportJava/.gitignore
+++ b/samples/DynamoDBExportJava/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.iml
+dependency-reduced-pom.xml

--- a/samples/DynamoDBExportJava/pom.xml
+++ b/samples/DynamoDBExportJava/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>DynamoDBExportSample</groupId>
+    <artifactId>DynamoDBExportSample</artifactId>
+    <version>0.1</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.10.33</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0-rc2</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.4.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.amazonaws.datapipelinesamples.ddbexport.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/samples/DynamoDBExportJava/readme.md
+++ b/samples/DynamoDBExportJava/readme.md
@@ -1,0 +1,49 @@
+# Data Pipeline DynamoDB Export Java Sample
+
+## Overview
+
+This sample makes it easy to create a pipeline that uses the latest DynamoDB export template EMR activity. You provide 
+parameters and the tool will create the pipeline and run and monitor it once so you can verify that it is healthy.
+
+This sample also provides an example application using the AWS Data Pipeline Java SDK. It demonstrates how to
+create, run and monitor a pipeline.
+
+## Prerequisites
+
+You must have the AWS CLI and default IAM roles setup in order to run the sample. Please see the 
+[readme](https://github.com/awslabs/data-pipeline-samples) for the base repository for instructions how to do this.
+
+
+## Getting started
+
+Build: mvn clean package <br/> <br/>
+View parameters description: java -jar path/to/DynamoDBExportSample-0.1.jar help <br/> <br/>
+Run: java -jar path/to/DynamoDBExportSample-0.1.jar  <-yourParam foo>
+
+## Example
+
+Create and run on a pipeline that runs once per day:
+
+java -jar /Users/foobar/DynamoDBExportJava/target/DynamoDBExportSample-0.1.jar -credentialsFile 
+/Users/foobar/.aws/credentials -myDDBTableName footable -myOutputS3Location s3://foobar/ddb-exports -schedule daily 
+-myLogsS3Location s3://foobar/logs -myDDBRegion us-east-1
+
+Create and run on a pipeline that runs once:
+
+java -jar /Users/foobar/DynamoDBExportJava/target/DynamoDBExportSample-0.1.jar -credentialsFile 
+/Users/foobar/.aws/credentials -myDDBTableName footable -myOutputS3Location s3://foobar/ddb-exports -schedule once 
+-myLogsS3Location s3://foobar/logs -myDDBRegion us-east-1
+
+## Disclaimer
+
+The samples in this repository are meant to help users get started with Data Pipeline. They may not be sufficient for 
+production environments. Users should carefully inspect code samples before running them.
+
+Use at your own risk.
+
+Copyright 2011-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the 
+License. A copy of the License is located at
+
+http://aws.amazon.com/asl/

--- a/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/CommandLineArgParser.java
+++ b/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/CommandLineArgParser.java
@@ -1,0 +1,67 @@
+package com.amazonaws.datapipelinesamples.ddbexport;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommandLineArgParser {
+    private static final Logger logger = LogManager.getLogger(CommandLineArgParser.class);
+
+    public static Map<String, String> parseParameters(final String[] args) {
+        Options params = new Options();
+        params.addOption("myDDBTableName", true, "Dynamo DB source table that will be exported (REQUIRED)");
+        params.addOption("myOutputS3Location", true, "S3 bucket where the export will be stored (REQUIRED)");
+        params.addOption("myLogsS3Location", true, "S3 bucket where the logs will be stored (REQUIRED)");
+        params.addOption("schedule", true, "Schedule to run pipeline on. Options are: once or daily (REQUIRED)");
+        params.addOption("credentialsFile", true, "Path to AWS credentials file. ex: /Users/foo/.aws/credentials " +
+                "(REQUIRED)");
+        params.addOption("myDDBRegion", true, "Region to run pipeline in. Default: us-east-1 (Optional)");
+
+        return getParamsMap(args, params);
+    }
+
+    private static Map<String, String> getParamsMap(final String[] args, final Options params) {
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd;
+        Map<String, String> paramsMap = new HashMap<>();
+
+        try {
+            cmd = parser.parse(params, args);
+            addToMapIfPreset(cmd, "credentialsFile", true, paramsMap);
+            addToMapIfPreset(cmd, "myDDBTableName", true, paramsMap);
+            addToMapIfPreset(cmd, "myOutputS3Location", true, paramsMap);
+            addToMapIfPreset(cmd, "myLogsS3Location", true, paramsMap);
+            addToMapIfPreset(cmd, "schedule", true, paramsMap);
+            addToMapIfPreset(cmd, "myDDBRegion", false, paramsMap);
+        } catch (ParseException | RuntimeException e) {
+            logger.error(e.getMessage());
+            printHelp(params);
+            throw new RuntimeException();
+        }
+
+        return paramsMap;
+    }
+
+    private static void printHelp(final Options params) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("maven", params);
+    }
+
+    private static void addToMapIfPreset(final CommandLine cmd, final String paramName, final boolean required,
+                                         final Map<String,String> paramsMap) {
+        if(cmd.hasOption(paramName)) {
+            paramsMap.put(paramName, cmd.getOptionValue(paramName));
+        } else if (required) {
+            logger.error("Unable to find required parameter: " + paramName);
+            throw new RuntimeException();
+        }
+    }
+}

--- a/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/DDBExportPipelineCreator.java
+++ b/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/DDBExportPipelineCreator.java
@@ -1,0 +1,103 @@
+package com.amazonaws.datapipelinesamples.ddbexport;
+
+import com.amazonaws.services.datapipeline.DataPipelineClient;
+import com.amazonaws.services.datapipeline.model.ActivatePipelineRequest;
+import com.amazonaws.services.datapipeline.model.CreatePipelineRequest;
+import com.amazonaws.services.datapipeline.model.CreatePipelineResult;
+import com.amazonaws.services.datapipeline.model.ParameterValue;
+import com.amazonaws.services.datapipeline.model.PipelineObject;
+import com.amazonaws.services.datapipeline.model.PutPipelineDefinitionRequest;
+import com.amazonaws.services.datapipeline.model.PutPipelineDefinitionResult;
+import com.google.common.collect.Lists;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class DDBExportPipelineCreator {
+
+    private static final Logger logger = LogManager.getLogger(DDBExportPipelineCreator.class);
+    private final static String name = "DDB Export Java Sample";
+    private final static String uniqueId  = UUID.randomUUID().toString();
+
+    public static String createPipeline(DataPipelineClient dataPipelineClient) {
+        CreatePipelineRequest createPipelineRequest = new CreatePipelineRequest().withName(name)
+                .withUniqueId(uniqueId);
+        CreatePipelineResult createPipelineResult = dataPipelineClient.createPipeline(createPipelineRequest);
+        String pipelineId = createPipelineResult.getPipelineId();
+        logger.info("Created pipeline id: " + pipelineId);
+        return pipelineId;
+    }
+
+    public static void putPipelineDefinition(final DataPipelineClient dataPipelineClient, final String pipelineId,
+                                             final Map<String, String> params) {
+
+        List<PipelineObject> pipelineObjectList = getPipelineObjects(params.get("schedule"));
+
+        List<ParameterValue> parameterValues = getParameterValues(params);
+
+        PutPipelineDefinitionRequest putPipelineDefinition = new PutPipelineDefinitionRequest()
+                .withPipelineId(pipelineId).withParameterValues(parameterValues).withPipelineObjects(pipelineObjectList);
+
+        PutPipelineDefinitionResult putPipelineResult = dataPipelineClient.putPipelineDefinition(putPipelineDefinition);
+
+        if (putPipelineResult.isErrored()) {
+            logger.error("Error found in pipeline definition: ");
+            putPipelineResult.getValidationErrors().stream().forEach(e -> logger.error(e));
+            throw new RuntimeException("Error in pipeline definition.");
+        }
+
+        if (putPipelineResult.getValidationWarnings().size() > 0) {
+            logger.warn("Warnings found in definition: ");
+            putPipelineResult.getValidationWarnings().stream().forEach(e -> logger.warn(e));
+        }
+
+        logger.info("Created pipeline definition");
+    }
+
+    private static List<PipelineObject> getPipelineObjects(final String scheduleType) {
+        PipelineObject schedule = DDBExportPipelineObjectCreator.getRunDailySchedule();
+        if(scheduleType.contains("once")) {
+            schedule = DDBExportPipelineObjectCreator.getRunOnceSchedule();
+        }
+
+        PipelineObject defaultObject = DDBExportPipelineObjectCreator.getDefault();
+        PipelineObject ddbSourceTable = DDBExportPipelineObjectCreator.getDDBSourceTable();
+        PipelineObject s3BackupLocation = DDBExportPipelineObjectCreator.getS3BackupLocation();
+        PipelineObject emrCluster = DDBExportPipelineObjectCreator.getEMRCluster();
+        PipelineObject emrActivity = DDBExportPipelineObjectCreator.getEMRActivity();
+
+        return Lists.newArrayList(schedule, defaultObject, ddbSourceTable,
+                s3BackupLocation, emrCluster, emrActivity);
+    }
+
+    private static List<ParameterValue> getParameterValues(final Map<String,String> params) {
+        String region = "us-east-1";
+        if(params.containsKey("myDDBRegion")) {
+            region = params.get("myDDBRegion");
+        }
+
+        ParameterValue ddbRegion = new ParameterValue().withId("myDDBRegion").withStringValue(region);
+        ParameterValue myDDBTableName = new ParameterValue().withId("myDDBTableName")
+                .withStringValue(params.get("myDDBTableName"));
+        ParameterValue myDDBReadThroughputRatio = new ParameterValue().withId("myDDBReadThroughputRatio")
+                .withStringValue("0.25");
+        ParameterValue myOutputS3Location = new ParameterValue().withId("myOutputS3Location")
+                .withStringValue(params.get("myOutputS3Location"));
+        ParameterValue myLogsS3Location = new ParameterValue().withId("myLogsS3Location")
+                .withStringValue(params.get("myLogsS3Location"));
+        ParameterValue myResizeClusterBeforeRunning = new ParameterValue().withId("myResizeClusterBeforeRunning")
+                .withStringValue("true");
+
+        return Lists.newArrayList(ddbRegion, myDDBTableName, myDDBReadThroughputRatio, myOutputS3Location,
+                myResizeClusterBeforeRunning, myLogsS3Location);
+    }
+
+    public static void activatePipeline(final DataPipelineClient dataPipelineClient, final String pipelineId) {
+        ActivatePipelineRequest activatePipelineRequest = new ActivatePipelineRequest().withPipelineId(pipelineId);
+        dataPipelineClient.activatePipeline(activatePipelineRequest);
+        logger.info("Pipeline activated");
+    }
+}

--- a/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/DDBExportPipelineObjectCreator.java
+++ b/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/DDBExportPipelineObjectCreator.java
@@ -1,0 +1,132 @@
+package com.amazonaws.datapipelinesamples.ddbexport;
+
+import com.amazonaws.services.datapipeline.model.Field;
+import com.amazonaws.services.datapipeline.model.PipelineObject;
+import com.google.common.collect.Lists;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DDBExportPipelineObjectCreator {
+
+    public static PipelineObject getDefault() {
+        String name = "Default";
+        String id = "Default";
+
+        Field type = new Field().withKey("scheduleType").withStringValue("CRON");
+        Field scheduleType = new Field().withKey("schedule").withRefValue("Schedule");
+        Field failureAndRerunMode = new Field().withKey("failureAndRerunMode").withStringValue("CASCADE");
+        Field role = new Field().withKey("role").withStringValue("DataPipelineDefaultRole");
+        Field resourceRole = new Field().withKey("resourceRole").withStringValue("DataPipelineDefaultResourceRole");
+        Field pipelineLogURI = new Field().withKey("pipelineLogUri").withStringValue("#{myLogsS3Location}");
+
+        List<Field> fieldsList = Lists.newArrayList(type, scheduleType, failureAndRerunMode,
+                role, resourceRole, pipelineLogURI);
+
+        return new PipelineObject().withName(name).withId(id).withFields(fieldsList);
+    }
+
+    public static PipelineObject getRunOnceSchedule() {
+        String name = "RunOnceSchedule";
+        String id = "Schedule";
+
+        Field type = new Field().withKey("type").withStringValue("Schedule");
+        Field startAt = new Field().withKey("startAt").withStringValue("FIRST_ACTIVATION_DATE_TIME");
+        Field period = new Field().withKey("period").withStringValue("1 day");
+        Field occurrences = new Field().withKey("occurrences").withStringValue("1");
+
+        List<Field> fieldsList = Lists.newArrayList(type, startAt, period, occurrences);
+
+        return new PipelineObject().withName(name).withId(id).withFields(fieldsList);
+    }
+
+    public static PipelineObject getRunDailySchedule() {
+        String name = "DailySchedule";
+        String id = "Schedule";
+
+        Field type = new Field().withKey("type").withStringValue("Schedule");
+        Field startAt = new Field().withKey("startAt").withStringValue("FIRST_ACTIVATION_DATE_TIME");
+        Field period = new Field().withKey("period").withStringValue("1 day");
+
+        List<Field> fieldsList = Lists.newArrayList(type, startAt, period);
+
+        return new PipelineObject().withName(name).withId(id).withFields(fieldsList);
+    }
+
+    public static PipelineObject getDDBSourceTable() {
+        String name = "DDBSourceTable";
+        String id = "DDBSourceTable";
+
+        Field type = new Field().withKey("type").withStringValue("DynamoDBDataNode");
+        Field tableName = new Field().withKey("tableName").withStringValue("#{myDDBTableName}");
+        Field readThroughputPercent = new Field().withKey("readThroughputPercent")
+                .withStringValue("#{myDDBReadThroughputRatio}");
+
+        List<Field> fieldsList = Lists.newArrayList(tableName, type, readThroughputPercent);
+
+        return new PipelineObject().withName(name).withId(id).withFields(fieldsList);
+    }
+
+    public static PipelineObject getS3BackupLocation() {
+        String name = "S3BackupLocation";
+        String id = "S3BackupLocation";
+
+        Field type = new Field().withKey("type").withStringValue("S3DataNode");
+        Field directoryPath = new Field().withKey("directoryPath")
+                .withStringValue("#{myOutputS3Location}#{format(@scheduledStartTime, 'YYYY-MM-dd-HH-mm-ss')}");
+
+        List<Field> fieldsList = Lists.newArrayList(type, directoryPath);
+
+        return new PipelineObject().withName(name).withId(id).withFields(fieldsList);
+    }
+
+    public static PipelineObject getEMRCluster() {
+        String name = "EmrClusterForBackup";
+        String id = "EmrClusterForBackup";
+
+        Field type = new Field().withKey("type").withStringValue("EmrCluster");
+        Field amiVersion = new Field().withKey("amiVersion").withStringValue("3.10.0");
+        Field masterInstanceType = new Field().withKey("masterInstanceType").withStringValue("m3.xlarge");
+        Field coreInstanceType = new Field().withKey("coreInstanceType").withStringValue("m3.xlarge");
+        Field coreInstanceCount = new Field().withKey("coreInstanceCount").withStringValue("1");
+        Field region = new Field().withKey("region").withStringValue("#{myDDBRegion}");
+        Field terminateAfter = new Field().withKey("terminateAfter").withStringValue("12 hours");
+        Field bootstrapAction = new Field().withKey("bootstrapAction").withStringValue("s3://elasticmapreduce" +
+                "/bootstrap-actions/configure-hadoop, --yarn-key-value,yarn.nodemanager.resource.memory-mb=11520," +
+                "--yarn-key-value,yarn.scheduler.maximum-allocation-mb=11520," +
+                "--yarn-key-value,yarn.scheduler.minimum-allocation-mb=1440," +
+                "--yarn-key-value,yarn.app.mapreduce.am.resource.mb=2880," +
+                "--mapred-key-value,mapreduce.map.memory.mb=5760," +
+                "--mapred-key-value,mapreduce.map.java.opts=-Xmx4608M," +
+                "--mapred-key-value,mapreduce.reduce.memory.mb=2880," +
+                "--mapred-key-value,mapreduce.reduce.java.opts=-Xmx2304m," +
+                "--mapred-key-value,mapreduce.map.speculative=false");
+
+        List<Field> fieldsList = Lists.newArrayList(type, amiVersion, masterInstanceType,
+                coreInstanceCount, coreInstanceType, region, terminateAfter, bootstrapAction);
+
+        return new PipelineObject().withName(name).withId(id).withFields(fieldsList);
+    }
+
+    public static PipelineObject getEMRActivity() {
+        String name = "TableBackupActivity";
+        String id = "TableBackupActivity";
+
+        Field type = new Field().withKey("type").withStringValue("EmrActivity");
+        Field input = new Field().withKey("input").withRefValue("DDBSourceTable");
+        Field output = new Field().withKey("output").withRefValue("S3BackupLocation");
+        Field runsOn = new Field().withKey("runsOn").withRefValue("EmrClusterForBackup");
+        Field resizeClusterBeforeRunning = new Field().withKey("resizeClusterBeforeRunning")
+                .withStringValue("#{myResizeClusterBeforeRunning}");
+        Field maximumRetries = new Field().withKey("maximumRetries").withStringValue("2");
+        Field step = new Field().withKey("step").withStringValue("s3://dynamodb-emr-#{myDDBRegion}/emr-ddb-storage-" +
+                "handler/2.1.0/emr-ddb-2.1.0.jar,org.apache.hadoop.dynamodb.tools.DynamoDbExport," +
+                "#{output.directoryPath},#{input.tableName},#{input.readThroughputPercent}");
+
+        List<Field> fieldsList = Lists.newArrayList(type, input, output, runsOn,
+                resizeClusterBeforeRunning, maximumRetries, step);
+
+        return new PipelineObject().withName(name).withId(id).withFields(fieldsList);
+    }
+}

--- a/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/Main.java
+++ b/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/Main.java
@@ -1,0 +1,31 @@
+package com.amazonaws.datapipelinesamples.ddbexport;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.services.datapipeline.DataPipelineClient;
+
+import java.util.Map;
+
+public class Main {
+
+    private static DataPipelineClient dataPipelineClient;
+
+    public static void main(String args[]) {
+        Map<String, String> params = CommandLineArgParser.parseParameters(args);
+
+        dataPipelineClient = getClient(params.get("credentialsFile"));
+
+        String pipelineId = DDBExportPipelineCreator.createPipeline(dataPipelineClient);
+
+        DDBExportPipelineCreator.putPipelineDefinition(dataPipelineClient, pipelineId, params);
+
+        DDBExportPipelineCreator.activatePipeline(dataPipelineClient, pipelineId);
+
+        PipelineMonitor.monitorPipelineUntilCompleted(dataPipelineClient, pipelineId, "TableBackupActivity");
+    }
+
+    private static DataPipelineClient getClient(final String profileName) {
+        AWSCredentials credentials = new ProfileCredentialsProvider(profileName, "default").getCredentials();
+        return new DataPipelineClient(credentials);
+    }
+}

--- a/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/PipelineMonitor.java
+++ b/samples/DynamoDBExportJava/src/main/java/com/amazonaws/datapipelinesamples/ddbexport/PipelineMonitor.java
@@ -1,0 +1,57 @@
+package com.amazonaws.datapipelinesamples.ddbexport;
+
+import com.amazonaws.services.datapipeline.DataPipelineClient;
+import com.amazonaws.services.datapipeline.model.DescribeObjectsRequest;
+import com.amazonaws.services.datapipeline.model.DescribeObjectsResult;
+import com.amazonaws.services.datapipeline.model.Field;
+import com.amazonaws.services.datapipeline.model.QueryObjectsRequest;
+import com.amazonaws.services.datapipeline.model.QueryObjectsResult;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.stream.Collectors;
+
+public class PipelineMonitor {
+
+    private static final Logger logger = LogManager.getLogger(DDBExportPipelineCreator.class);
+
+    public static void monitorPipelineUntilCompleted(final DataPipelineClient dataPipelineClient,
+                                                     final String pipelineId, final String activityName) {
+        Timer timer = new Timer();
+        int thirtySeconds = 30 * 1000;
+        timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                QueryObjectsRequest queryObjectsRequest = new QueryObjectsRequest().withPipelineId(pipelineId)
+                        .withSphere("INSTANCE");
+                QueryObjectsResult result = dataPipelineClient.queryObjects(queryObjectsRequest);
+
+                if(result.getIds().size() <= 0) {
+                    logger.info("Creating pipeline object execution graph");
+                    return;
+                }
+
+                String emrActivityId = result.getIds().stream().filter(r -> r.contains(activityName))
+                        .collect(Collectors.joining("\n"));
+                DescribeObjectsResult describeObjectsResult = dataPipelineClient
+                        .describeObjects(new DescribeObjectsRequest().withObjectIds(emrActivityId)
+                                .withPipelineId(pipelineId));
+
+                String status = "";
+                for(Field field : describeObjectsResult.getPipelineObjects().get(0).getFields()) {
+                    if (field.getKey().equals("@status")) {
+                        logger.info(field.getKey() + "=" + field.getStringValue());
+                        status = field.getStringValue();
+                    }
+                }
+
+                if (status.equals("CANCELED") || status.equals("FINISHED") || status.equals("FAILED")) {
+                    this.cancel();
+                    timer.cancel();
+                }
+            }
+        }, 0, thirtySeconds);
+    }
+}

--- a/samples/DynamoDBExportJava/src/main/resources/log4j2.xml
+++ b/samples/DynamoDBExportJava/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%level] %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This sample makes it easy to create a pipeline that uses the latest DynamoDB export template EMR activity. You provide parameters and the tool will create the pipeline and run and monitor it once so you can verify that it is healthy.

This sample also provides an example application using the AWS Data Pipeline Java SDK. It demonstrates how to create, run and monitor a pipeline.
