### PR TITLE
Remove asterisk from parameter name to match doc

### DIFF
--- a/samples/DynamoDBToRedshiftConvertDataUsingHive/DynamoDBtoRedshiftHiveCSV.json
+++ b/samples/DynamoDBToRedshiftConvertDataUsingHive/DynamoDBtoRedshiftHiveCSV.json
@@ -105,7 +105,7 @@
       "connectionString": "jdbc:postgresql://#{myRedshiftEndpoint}:5439/dev",
       "type": "RedshiftDatabase",
       "username": "#{myRedshiftUsername}",
-      "*password": "#{*myRedshiftPassword}"
+      "*password": "#{myRedshiftPassword}"
     },
     {
       "myComment": "This object provides the configuration for the EMR cluster.",


### PR DESCRIPTION
The template has an asterisk in the parameter name, I've removed it so it matches the doc.

Should the doc be updated instead?
