### PR TITLE
Changing instance type "t1-micro" to "t2-micro"

### DIFF
--- a/samples/EFSBackup/1-Node-EFSBackupPipeline.json
+++ b/samples/EFSBackup/1-Node-EFSBackupPipeline.json
@@ -62,7 +62,7 @@
       "default" : "m3.medium",
       "description" : "Instance type for creating backups.",
       "allowedValues" : [
-        "t1.micro",
+        "t2.micro",
         "m3.medium",
         "m3.large",
         "m3.xlarge",


### PR DESCRIPTION
The "t1-micro" instance type is not available anymore.